### PR TITLE
Fix beam projectiles

### DIFF
--- a/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab
+++ b/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab
@@ -1,0 +1,327 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &175464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 458768}
+  - 212: {fileID: 21249720}
+  - 60: {fileID: 6009790}
+  - 50: {fileID: 5060920}
+  - 114: {fileID: 114000011340133002}
+  m_Layer: 12
+  m_Name: BeamEnemy
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &458768
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 175464}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!50 &5060920
+Rigidbody2D:
+  serializedVersion: 2
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 175464}
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!60 &6009790
+PolygonCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 175464}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Points:
+    m_Paths:
+    - - {x: 0.26999998, y: -0.905}
+      - {x: 0.32, y: -0.84499997}
+      - {x: 0.55, y: -0.505}
+      - {x: 0.55, y: -0.265}
+      - {x: 0.39, y: -0.16499999}
+      - {x: 0.26, y: -0.015}
+      - {x: 0.19, y: 0.195}
+      - {x: 0.14999999, y: 0.45499998}
+      - {x: 0.089999996, y: 0.505}
+      - {x: 0.089999996, y: 0.59499997}
+      - {x: 0.08, y: 0.825}
+      - {x: 0.03, y: 0.97499996}
+      - {x: -0.04, y: 0.97499996}
+      - {x: -0.08, y: 0.815}
+      - {x: -0.089999996, y: 0.59499997}
+      - {x: -0.14, y: 0.445}
+      - {x: -0.24, y: 0.044999998}
+      - {x: -0.32, y: -0.085}
+      - {x: -0.39, y: -0.175}
+      - {x: -0.55, y: -0.275}
+      - {x: -0.55, y: -0.515}
+      - {x: -0.29999998, y: -0.875}
+      - {x: -0.26, y: -0.905}
+      - {x: -0.11, y: -0.905}
+      - {x: -0.04, y: -0.825}
+      - {x: 0.089999996, y: -0.875}
+      - {x: 0.12, y: -0.905}
+--- !u!212 &21249720
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 175464}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 1
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: a278fa2547c98dd4093949664a70324a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedObjects.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: fireRate
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Mass
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Offset.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[7]
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: tagFilter
+      value: Friendly
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[3]
+      value: true
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: fireTargetPrefab
+      value: 
+      objectReference: {fileID: 190474, guid: 8d3d7bfa3fbc59c43bb76875b3035098, type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[4]
+      value: true
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: moveTargetPrefab
+      value: 
+      objectReference: {fileID: 101710, guid: 86c82ccd2da3b5442bc7c82a5d005f4f, type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 11475746, guid: cf2028e7f9cea8542a329e926e952ef9,
+        type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedObjects.Array.data[1]
+      value: 
+      objectReference: {fileID: 11426396, guid: 2eac2216e280476408c01d7d9ab89145,
+        type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[2]
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: bulletPrefab
+      value: 
+      objectReference: {fileID: 11442878, guid: 77694c588ffd7ce4ebeb88b115da8bfe,
+        type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[0]
+      value: '{"$content":[0]}'
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: maxHealth
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[5]
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[6]
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: HealthBar
+      value: 
+      objectReference: {fileID: 167222, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[8]
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: damageGUIPrefab
+      value: 
+      objectReference: {fileID: 103538, guid: b0cf55af6b69c8f4ca18aa93ea4778ba, type: 2}
+    - target: {fileID: 0}
+      propertyPath: healthBarPrefab
+      value: 
+      objectReference: {fileID: 160722, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[1]
+      value: '{"$content":[1]}'
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: MaxHealth
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: FacePlayer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_IsKinematic
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_CollisionDetection
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackBehaviors.Array.data[0]
+      value: 
+      objectReference: {fileID: 11475746, guid: cf2028e7f9cea8542a329e926e952ef9,
+        type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedObjects.Array.data[2]
+      value: 
+      objectReference: {fileID: 103538, guid: b0cf55af6b69c8f4ca18aa93ea4778ba, type: 2}
+    - target: {fileID: 0}
+      propertyPath: movementBehaviors.Array.data[0]
+      value: 
+      objectReference: {fileID: 11426396, guid: 2eac2216e280476408c01d7d9ab89145,
+        type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 175464}
+  m_IsPrefabParent: 1
+--- !u!114 &114000011340133002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 175464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 394699218fafdc94e9f2a68fddd06656, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _serializationData:
+    serializedObjects:
+    - {fileID: 11442878, guid: b09754002c5d8bb40b02638170a9eade, type: 2}
+    - {fileID: 160722, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
+    serializedStrings:
+      keys:
+      - DanmakuPrefab bulletPrefab
+      - Player Player
+      - DanmakuField Field
+      - Wave Wave
+      - int Difficulty
+      - int MaxHealth
+      - int Health
+      - bool FacePlayer
+      - GameObject healthBarPrefab
+      - string tagFilter
+      values:
+      - 0
+      - null
+      - null
+      - null
+      - 0
+      - 100
+      - 0
+      - false
+      - 1
+      - null
+  _serializerType:
+    _name: Vexe.Runtime.Serialization.FullSerializerBackend, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  _id: -8876
+  dbg: 0
+  _dirty: 0
+  tagFilter: 
+  Player: {fileID: 0}
+  Field: {fileID: 0}
+  Wave: {fileID: 0}
+  Difficulty: 0
+  MaxHealth: 100
+  Health: 0
+  FacePlayer: 0
+  healthBarPrefab: {fileID: 160722, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
+  bulletPrefab: {fileID: 11442878, guid: b09754002c5d8bb40b02638170a9eade, type: 2}

--- a/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab.meta
+++ b/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a30d93d3fd6d0694693dc572d3cd4dc5
+timeCreated: 1473635881
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Projectile/Beam.prefab
+++ b/Assets/Prefabs/Projectile/Beam.prefab
@@ -12,7 +12,7 @@ GameObject:
   - 114: {fileID: 11442878}
   m_Layer: 14
   m_Name: Beam
-  m_TagString: Enemy
+  m_TagString: Laser
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -24,8 +24,9 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 125412}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 50, z: 0}
   m_LocalScale: {x: 1, y: 100, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -53,8 +54,8 @@ MonoBehaviour:
       - IDanmakuController[] extraControllers
       values:
       - 0
-      - '"Line"'
-      - '{"x":0.800000011920929,"y":1.0}'
+      - '"Box"'
+      - '{"x":1.0,"y":100.0}'
       - '{"x":0.0,"y":0.0}'
       - false
       - '[]'
@@ -75,17 +76,20 @@ SpriteRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 4330258e1a878ef4ba58c7bcfd36f9c0, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedWireframeHidden: 1
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89

--- a/Assets/Resources/Free/bullet beam.png.meta
+++ b/Assets/Resources/Free/bullet beam.png.meta
@@ -30,7 +30,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     filterMode: -1
-    aniso: -1
+    aniso: 16
     mipBias: -1
     wrapMode: 1
   nPOTScale: 0
@@ -41,14 +41,16 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
-  alignment: 0
+  alignment: 7
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
+  spriteTessellationDetail: -1
   textureType: 8
   buildTargetSettings: []
   spriteSheet:
+    serializedVersion: 2
     sprites: []
     outline: []
   spritePackingTag: 

--- a/Assets/Scripts/Core/Player.cs
+++ b/Assets/Scripts/Core/Player.cs
@@ -90,7 +90,7 @@ public class Player : DanmakuCollider
     public override void Awake()
     {
         base.Awake();
-        TagFilter = "Enemy";
+        TagFilter = "Enemy|Laser";
 
         // Retrieve references
         field = LevelController.Singleton.Field;
@@ -323,7 +323,8 @@ public class Player : DanmakuCollider
     /// <param name="info">Information about the collision</param>
     protected override void DanmakuCollision(Danmaku danmaku, RaycastHit2D info)
     {
-        danmaku.Deactivate();
+        if (danmaku.Tag != "Laser")
+            danmaku.Deactivate();
         if(!dashing && !invincible)
         {
             Hit();

--- a/Assets/Scripts/Enemy/Test/BeamEnemy.cs
+++ b/Assets/Scripts/Enemy/Test/BeamEnemy.cs
@@ -1,0 +1,46 @@
+﻿using UnityEngine;
+using System.Collections;
+using DanmakU;
+using DanmakU.Controllers;
+
+public class BeamEnemy : Enemy
+{
+    public DanmakuPrefab bulletPrefab;
+
+    private FireBuilder fireData;
+    private Rigidbody2D rigidbody2d;
+
+    public override void Start()
+    {
+        rigidbody2d = GetComponent<Rigidbody2D>();
+
+        fireData = new FireBuilder(bulletPrefab, Field);
+        fireData.From(transform);
+        fireData.WithSpeed(0);
+        fireData.WithController(new AutoDeactivateController(2.0f));
+
+        base.Start();
+    }
+
+    protected override IEnumerator Run()
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            // Moving left
+            FacePlayer = true;
+            rigidbody2d.velocity = new Vector2(-5, 0);
+            yield return new WaitForSeconds(2);
+
+            // Stop and face player
+            rigidbody2d.velocity = Vector2.zero;
+            fireData.Towards(Player.transform.position);
+            FacePlayer = false;
+
+            // Fire
+            yield return new WaitForSeconds(0.5f);
+            fireData.Fire();
+            yield return new WaitForSeconds(2.0f);
+        }
+        Die();
+    }
+}

--- a/Assets/Scripts/Enemy/Test/BeamEnemy.cs.meta
+++ b/Assets/Scripts/Enemy/Test/BeamEnemy.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 394699218fafdc94e9f2a68fddd06656
+timeCreated: 1475902927
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`DanmakuCollision` in `Player` now checks for the `Laser` tag before calling `danmaku.deactivate()`, allowing beam projectiles to persist through collisions.

Should have tester enemy BeamEnemy based off the CoroutineEnemy
