### PR TITLE
Fix beam hitbox

### DIFF
--- a/Assets/Prefabs/Projectile/Beam.prefab
+++ b/Assets/Prefabs/Projectile/Beam.prefab
@@ -24,8 +24,8 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 125412}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 50, z: 0}
-  m_LocalScale: {x: 1, y: 100, z: 1}
+  m_LocalPosition: {x: 0, y: 40, z: 0}
+  m_LocalScale: {x: 1, y: 80, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
@@ -55,8 +55,8 @@ MonoBehaviour:
       values:
       - 0
       - '"Box"'
-      - '{"x":1.0,"y":100.0}'
-      - '{"x":0.0,"y":0.0}'
+      - '{"x":1.0,"y":80.0}'
+      - '{"x":40.0,"y":0.0}'
       - false
       - '[]'
   _serializerType:


### PR DESCRIPTION
`Beam` should no longer hit behind units and should line up with the render properly. 

Beam length is current set to 80, but can be changed by changing the prefab y-scale and then setting the y-position to half of the scale value, the hitbox y-size to the scale, and the hitbox x-offset to half of the scale value.
