### PR TITLE
Fix beam bugs

### DIFF
--- a/Assets/ExternalLibraries/DanmakU/Core/Controllers/EnemyDeathController.cs
+++ b/Assets/ExternalLibraries/DanmakU/Core/Controllers/EnemyDeathController.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+using Vexe.Runtime.Types;
+
+namespace DanmakU.Controllers
+{
+
+    // A Danmaku controller that deactivates bullets if the linked unit dies
+    [System.Serializable]
+    public class EnemyDeathController : IDanmakuController
+    {
+        
+        private Enemy link;
+
+        public EnemyDeathController(Enemy link = null)
+        {
+            this.link = link;
+        }
+        
+        #region IDanmakuController implementation
+
+        public void Update(Danmaku danmaku, float dt)
+        {
+            if (!link)
+            {
+                danmaku.IsActive = false;
+            }
+        }
+
+        #endregion
+
+    }
+
+}

--- a/Assets/ExternalLibraries/DanmakU/Core/Controllers/EnemyDeathController.cs.meta
+++ b/Assets/ExternalLibraries/DanmakU/Core/Controllers/EnemyDeathController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 11b5853ee21587e40948dc15bfb38bc6
+timeCreated: 1478553045
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ExternalLibraries/DanmakU/Core/Danmaku.cs
+++ b/Assets/ExternalLibraries/DanmakU/Core/Danmaku.cs
@@ -497,7 +497,7 @@ namespace DanmakU
                     }
                 }
             }
-            if(!is_active || (Field != null && !Field.bounds.Contains(position)))
+            if(!is_active || (Field != null && !Field.bounds.Contains(position) && Tag != "Laser"))
             {
                 DeactivateImmediate();
                 return;

--- a/Assets/ExternalLibraries/DanmakU/Core/DanmakuPrefab.cs
+++ b/Assets/ExternalLibraries/DanmakU/Core/DanmakuPrefab.cs
@@ -387,6 +387,10 @@ namespace DanmakU {
 				renderMesh.vertices = vertexes;
 				renderMesh.Optimize();
 			}
+
+            // Hacky fix for lasers disappearing when center is off screen (by enlargening the bounds to cover the size of the laser)
+            if (Tag == "Laser")
+                renderMesh.bounds = new Bounds(Vector3.zero, new Vector3(1, colliderSize.y * 2, 1)); 
 			
 			runtimeRenderer.mesh = renderMesh;
 

--- a/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab
+++ b/Assets/Prefabs/Enemy/Test/BeamEnemy.prefab
@@ -284,10 +284,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _serializationData:
     serializedObjects:
+    - {fileID: 11442878, guid: fd1b1dcd956c33f41a9b7f1cb043d259, type: 2}
     - {fileID: 11442878, guid: b09754002c5d8bb40b02638170a9eade, type: 2}
     - {fileID: 160722, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
     serializedStrings:
       keys:
+      - DanmakuPrefab warningPrefab
       - DanmakuPrefab bulletPrefab
       - Player Player
       - DanmakuField Field
@@ -300,6 +302,7 @@ MonoBehaviour:
       - string tagFilter
       values:
       - 0
+      - 1
       - null
       - null
       - null
@@ -307,7 +310,7 @@ MonoBehaviour:
       - 100
       - 0
       - false
-      - 1
+      - 2
       - null
   _serializerType:
     _name: Vexe.Runtime.Serialization.FullSerializerBackend, Assembly-CSharp, Version=0.0.0.0,
@@ -324,4 +327,5 @@ MonoBehaviour:
   Health: 0
   FacePlayer: 0
   healthBarPrefab: {fileID: 160722, guid: 00d10dde6764d52428e747996fbe6f5d, type: 2}
+  warningPrefab: {fileID: 11442878, guid: fd1b1dcd956c33f41a9b7f1cb043d259, type: 2}
   bulletPrefab: {fileID: 11442878, guid: b09754002c5d8bb40b02638170a9eade, type: 2}

--- a/Assets/Prefabs/Projectile/BeamWarning.prefab
+++ b/Assets/Prefabs/Projectile/BeamWarning.prefab
@@ -1,0 +1,150 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &125412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 446412}
+  - 212: {fileID: 21289382}
+  - 114: {fileID: 11442878}
+  m_Layer: 14
+  m_Name: BeamWarning
+  m_TagString: Laser
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &446412
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 125412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 40, z: 0}
+  m_LocalScale: {x: 1, y: 80, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &11442878
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 125412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c585314c620ed714796db7e36d5eff23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _serializationData:
+    serializedObjects:
+    - {fileID: 19876622, guid: 1369960486de0844c8c02f62913f5ffb, type: 2}
+    serializedStrings:
+      keys:
+      - ParticleSystem danmakuSystemPrefab
+      - ColliderType collisionType
+      - Vector2 colliderSize
+      - Vector2 colliderOffset
+      - bool fixedAngle
+      - IDanmakuController[] extraControllers
+      values:
+      - 0
+      - '"Box"'
+      - '{"x":0.0,"y":0.0}'
+      - '{"x":0.0,"y":0.0}'
+      - false
+      - '[]'
+  _serializerType:
+    _name: Vexe.Runtime.Serialization.FullSerializerBackend, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  _id: -52638
+  dbg: 0
+  _dirty: 0
+  danmakuSystemPrefab: {fileID: 19876622, guid: 1369960486de0844c8c02f62913f5ffb,
+    type: 2}
+--- !u!212 &21289382
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 125412}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 4330258e1a878ef4ba58c7bcfd36f9c0, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 1
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 8224e8fe5d8a1d54780253baa7ffa620, type: 3}
+  m_Color: {r: 1, g: 0.847, b: 0.11764705, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 481ec54ae2068b442a9db57f4dd0aa50,
+        type: 3}
+    - target: {fileID: 0}
+      propertyPath: m_SortingLayerID
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 4330258e1a878ef4ba58c7bcfd36f9c0, type: 2}
+    - target: {fileID: 0}
+      propertyPath: _serializationData.serializedStrings.values.Array.data[5]
+      value: '[]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 125412}
+  m_IsPrefabParent: 1

--- a/Assets/Prefabs/Projectile/BeamWarning.prefab.meta
+++ b/Assets/Prefabs/Projectile/BeamWarning.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd1b1dcd956c33f41a9b7f1cb043d259
+timeCreated: 1466537424
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/Test/BeamEnemy.cs
+++ b/Assets/Scripts/Enemy/Test/BeamEnemy.cs
@@ -20,6 +20,7 @@ public class BeamEnemy : Enemy
         warningData.From(transform);
         warningData.WithSpeed(0);
         warningData.WithController(new AutoDeactivateController(1.0f));
+        warningData.WithController(new EnemyDeathController(this));
         ColorChangeController colorController = new ColorChangeController();
         GradientAlphaKey[] gak = new GradientAlphaKey[2];
         GradientColorKey[] gck = new GradientColorKey[2];
@@ -41,6 +42,7 @@ public class BeamEnemy : Enemy
         fireData.From(transform);
         fireData.WithSpeed(0);
         fireData.WithController(new AutoDeactivateController(2.0f));
+        fireData.WithController(new EnemyDeathController(this));
 
         base.Start();
     }

--- a/Assets/Scripts/Enemy/Test/BeamEnemy.cs
+++ b/Assets/Scripts/Enemy/Test/BeamEnemy.cs
@@ -5,14 +5,37 @@ using DanmakU.Controllers;
 
 public class BeamEnemy : Enemy
 {
+    public DanmakuPrefab warningPrefab;
     public DanmakuPrefab bulletPrefab;
 
     private FireBuilder fireData;
+    private FireBuilder warningData;
     private Rigidbody2D rigidbody2d;
 
     public override void Start()
     {
         rigidbody2d = GetComponent<Rigidbody2D>();
+
+        warningData = new FireBuilder(warningPrefab, Field);
+        warningData.From(transform);
+        warningData.WithSpeed(0);
+        warningData.WithController(new AutoDeactivateController(1.0f));
+        ColorChangeController colorController = new ColorChangeController();
+        GradientAlphaKey[] gak = new GradientAlphaKey[2];
+        GradientColorKey[] gck = new GradientColorKey[2];
+        gak[0].alpha = 0.0f;
+        gak[0].time = 0f;
+        gak[1].alpha = 1f;
+        gak[1].time = 1f;
+        gck[0].color = Color.red;
+        gck[0].time = 0f;
+        gck[1].color = Color.yellow;
+        gck[1].time = 1f;
+        colorController.ColorGradient = new Gradient();
+        colorController.ColorGradient.SetKeys(gck, gak);
+        colorController.StartTime = 0;
+        colorController.EndTime = 1;
+        warningData.WithController(colorController);
 
         fireData = new FireBuilder(bulletPrefab, Field);
         fireData.From(transform);
@@ -33,11 +56,13 @@ public class BeamEnemy : Enemy
 
             // Stop and face player
             rigidbody2d.velocity = Vector2.zero;
+            warningData.Towards(Player.transform.position);
             fireData.Towards(Player.transform.position);
             FacePlayer = false;
 
             // Fire
-            yield return new WaitForSeconds(0.5f);
+            warningData.Fire();
+            yield return new WaitForSeconds(1f);
             fireData.Fire();
             yield return new WaitForSeconds(2.0f);
         }


### PR DESCRIPTION
## Overview
This PR addresses beam projectile behavior when offscreen and when the source enemy is killed.

### Offscreen beams
Beams should now render even when all beam sources are off camera. 
This was accomplished by a hacky change extending the size of the projectile mesh to the length of the beam and not removing lasers that originate off-field. These changes will only apply to `DanmakU` that are tagged `Laser`.

### Enemy death
The `EnemyDeathController` can be added with the desired linked `Enemy` to allow the danmaku to be removed upon the removal of the linked unit. 